### PR TITLE
Ensure that Chrome with round version numbers don't get misclassified

### DIFF
--- a/data/rules.js
+++ b/data/rules.js
@@ -4,8 +4,8 @@ module.exports = [
   // iOS webview will be the same as safari but missing "Safari"
   '(iPhone|iPod|iPad)(?!.*Safari)',
   // Android Lollipop and Above: webview will be the same as native but it will contain "wv"
-  // Android KitKat to lollipop webview will put {version}.0.0.0
-  'Android.*(wv|.0.0.0)',
+  // Android KitKat to Lollipop webview will put Version/X.X Chrome/{version}.0.0.0
+  'Android.*(;\\s+wv|Version/\\d.\\d\\s+Chrome/\\d+(\\.0){3})',
   // old chrome android webview agent
   'Linux; U; Android'
 ]

--- a/test/data/not-webview.js
+++ b/test/data/not-webview.js
@@ -1,6 +1,8 @@
 module.exports = [
   // chrome android browser
   "Mozilla/5.0 (Linux; Android 4.4.4; One Build/KTU84L.H4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36",
+  // chrome android browser with round version number
+  "Mozilla/5.0 (Linux; Android 12; ingot) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Mobile Safari/537.36",
   // iPad Safari
   "Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) CriOS/30.0.1599.12 Mobile/11A465 Safari/8536.25",
   // iPhone Safari


### PR DESCRIPTION
From https://developer.chrome.com/docs/multidevice/user-agent/#webview-on-android:

> WebView UA in KitKat to Lollipop
>
>     Mozilla/5.0 (Linux; Android 4.4; Nexus 5 Build/_BuildID_) 
>     AppleWebKit/537.36 (KHTML, like Gecko) 
>     Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
>
> If you're attempting to differentiate between the WebView and Chrome for Android, you should look for the presence of the Version/_X.X_ string in the WebView user-agent string. Don't rely on the specific Chrome version number (for example, 30.0.0.0) as the version numbers changes with each release.

Closes #11.